### PR TITLE
Update sized vectors dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/csicar/purescript-sized-matrices.git"
   },
   "dependencies": {
-    "purescript-sized-vectors": "^3.1.0",
+    "purescript-sized-vectors": "^5.0.0",
     "purescript-prelude": "^4.0.1",
     "purescript-foldable-traversable": "^4.0.0",
     "purescript-maybe": "^4.0.0",

--- a/src/Data/Matrix/Operations.purs
+++ b/src/Data/Matrix/Operations.purs
@@ -2,9 +2,11 @@ module Data.Matrix.Operations where
 
 import Prelude
 import Data.Matrix
-import Data.Tuple (Tuple(..), snd)
+import Data.Tuple (Tuple(..), fst, snd)
 import Data.Foldable (class Foldable, foldMap, foldl, foldr, maximumBy, product)
-import Data.Vec (Vec, range')
+import Data.Function (on)
+import Data.FunctorWithIndex (mapWithIndex)
+import Data.Vec (Vec)
 import Data.Maybe (Maybe, fromJust, fromMaybe)
 import Data.Vec as Vec
 import Data.Typelevel.Num (class Pos, class Nat, class Succ, class Pred, d0, toInt)
@@ -69,12 +71,8 @@ snocRowVec vec (Matrix m) = Matrix $ Vec.snoc vec m
 snocColVec :: ∀h w w' a. Succ w w' => Nat h => Vec.Vec h a → Matrix h w a → Matrix h w' a
 snocColVec vec (Matrix m) = Matrix $ Vec.zipWithE (Vec.snoc) vec m
 
-
 findMaxIndex ∷ ∀s a. Ord a => Pos s => Vec s a → Int
-findMaxIndex vec = fromMaybe 0 $ map snd $ maximumBy (\(Tuple a _) (Tuple b _) → compare a b) withIndex
-  where
-    withIndex ∷ Vec s (Tuple a Int)
-    withIndex = Vec.zipWithE Tuple vec (range' 0)
+findMaxIndex vec = fromMaybe 0 $ map fst $ maximumBy (compare `on` snd) $ mapWithIndex Tuple vec
 
 -- | remove row at index. If index is out of bounds, there will be no change
 -- |

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,15 +3,22 @@ module Test.Main where
 import Prelude
 
 import Effect
+import Data.FunctorWithIndex (mapWithIndex)
+import Data.Foldable (maximumBy)
+import Data.Function (on)
 import Data.Int (pow)
 import Data.Matrix (Matrix(..), column, fill, height, replicate', row, unsafeIndex, width, zipWithE)
 import Data.Matrix.Reps (matrix11, matrix22, matrix33)
 import Data.Matrix.Transformations (resize, transpose, mkPermutation)
-import Data.Matrix.Operations ((⇥), (⤓))
+import Data.Matrix.Operations ((⇥), (⤓), findMaxIndex)
 import Data.Matrix.Algorithms (det, luDecomp, inverse)
+import Data.Maybe (fromJust)
 import Data.Rational (Rational, fromInt, (%))
+import Data.Tuple (Tuple(Tuple))
+import Data.Tuple as Tuple
 import Data.Typelevel.Num (D3, d0, d1)
-import Data.Vec (vec2)
+import Data.Vec (vec2, (+>))
+import Data.Vec as Vec
 import Test.QuickCheck (Result, (===))
 import Test.Unit (suite, test)
 import Test.Unit.Assert (equal)
@@ -224,3 +231,20 @@ main = runTest do
         sa = resize a
         sa' = matrix22 1.0 4.0 3.0 0.0
       equal sa' sa
+
+    test "findMaxIndex" do
+      quickCheck \(x :: Int) ->
+        (findMaxIndex (x +> Vec.empty)) === 0 
+      quickCheck \(x1 :: Int) x2 x3 ->
+        let
+          actual = findMaxIndex (x1 +> x2 +> x3 +> Vec.empty)
+          expected =
+            unsafePartial
+              ( [x1, x2, x3]
+                  # mapWithIndex Tuple
+                  # maximumBy (compare `on` Tuple.snd)
+                  # fromJust
+                  # Tuple.fst 
+              )
+        in
+          actual === expected 


### PR DESCRIPTION
- Added a test that makes the existing `findMaxIndex` pass.
- Updated `sized-vectors` dependency
- Changed the existing `findMaxIndex` to work with latest `sized-vectors` package.
