### PR TITLE
Compute matrix inverse using the adjungate

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,7 @@ Sized-Matrices
   [3,4]
   [5,6]
 > fromVec vec :: Matrix D2 D2 Int
-... will be an error, since dimentions don't match up
-> lrSplit $ matrix33 1.0 4.0 (0.0 - 1.0) 3.0 0.0 5.0 2.0 2.0 1.0
-  { l:
-      [1.0,0.0,0.0]
-      [3.0,1.0,0.0]
-      [2.0,0.5,1.0]
-  , r:
-      [1.0,4.0,-1.0]
-      [0.0,-12.0,8.0]
-      [0.0,0.0,-1.0]
-  }
+... will be an error, since dimensions don't match up
 ```
 
 Features
@@ -73,8 +63,7 @@ Features
 - typesafe size
 - Complete `Semiring` and `Ring` implementation
 - Matrix multiplication
-- transpose
-- matrix addition
+- Transpose
+- Matrix addition
 - Determinant
 - Inverse Matrix
-- LR splitting for solving linear equasion systems

--- a/src/Data/Matrix/Algorithms.purs
+++ b/src/Data/Matrix/Algorithms.purs
@@ -1,4 +1,4 @@
-module Data.Matrix.Algorithms (det, cofactor, cofactorMatrix) where
+module Data.Matrix.Algorithms (det, inverse, cofactor, cofactorMatrix, adjunct) where
 
 import Data.Matrix
 import Prelude
@@ -22,10 +22,10 @@ import Data.Vec as Vec
 import Partial.Unsafe (unsafePartial)
 
 cofactorMatrix :: ∀s a. Pos s => EuclideanRing a => Matrix s s a -> Matrix s s a 
-cofactorMatrix m = fill (\x y -> cofactor x y m)
+cofactorMatrix m = fill $ \j i -> cofactor i j m
 
 cofactor :: ∀s a. Pos s => EuclideanRing a => CommutativeRing a => Int -> Int -> Matrix s s a -> a 
-cofactor i j m = (signFor i j) * det' (removeCross i j (toArray m)) 
+cofactor i j m = (signFor i j) * det' (removeCross i j (toArray m))
   where 
     signFor i j
       | even (i+j) = one
@@ -36,7 +36,17 @@ cofactor i j m = (signFor i j) * det' (removeCross i j (toArray m))
     deleteAt' :: ∀a. Int -> Array a -> Array a 
     deleteAt' i m' = unsafePartial $ fromJust $ deleteAt i m'
 
--- | calculate determinant for matrix.
+adjunct :: ∀s a. Pos s => Field a => Matrix s s a -> Matrix s s a
+adjunct = cofactorMatrix >>> transpose
+
+-- | Computes the multiplicative inverse of a regular matrix.
+-- | The function uses [Cramer's Rule](https://en.wikipedia.org/wiki/Cramer%27s_rule) for the computation.
+-- Implementation reference:
+-- https://de.wikipedia.org/wiki/Inverse_Matrix#Berechnung#Darstellung_über_die_Adjunkte
+inverse :: ∀s a. Pos s => Field a => Matrix s s a -> Matrix s s a
+inverse m = map (_ * recip (det m)) $ adjunct m
+
+-- | calculate the determinant for matrix.
 det ∷ ∀s a. CommutativeRing a => EuclideanRing a => Pos s => Matrix s s a → a
 det m = det' (toArray m)
 

--- a/src/Data/Matrix/RegularMatrices.purs
+++ b/src/Data/Matrix/RegularMatrices.purs
@@ -15,3 +15,6 @@ derive newtype instance foldableVec ∷ (Nat s) => Foldable (RegularMatrix s)
 derive newtype instance eqMatrix ∷ (Eq a, Nat s) => Eq (RegularMatrix s a)
 derive newtype instance semiringMatrix :: (Nat s, CommutativeRing a) => Semiring (RegularMatrix s a)
 derive newtype instance ringMatrix :: (Nat s, CommutativeRing a) => Ring (RegularMatrix s a)
+
+instance divisionRingMatrix :: (Pos s, Field a) => DivisionRing (RegularMatrix s a) where
+  recip (RegularMatrix a) = RegularMatrix $ inverse a


### PR DESCRIPTION
I tested this and it seems to work fine.

Using quickCheck to check the inverse property (`A * A^-1 = I`) would be nice, but would require checking that they are regular matrices first.

Using cramer's rule does not scale well; computation for large matrices (even 9x9) will be very slow.