### PR TITLE
CI Cache for Bower Cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,11 @@
 
 image: registry.gitlab.com/csicar/purescript-sized-matrices
 
+cache:
+   key: "$CI_COMMIT_REF_SLUG"
+   paths:
+      - /home/pureuser/.cache/bower
+
 build:
    stage: build
    script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,4 +10,6 @@ build:
    stage: build
    script:
       - bower install
+      - ls ~/.cache/bower
+      - ls /home/pureuser/.cache/bower
       - pulp test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,20 +6,27 @@ cache:
    paths:
       - .bower_cache
 
+# Moves the bower-cache files into .bower_cache, since
+# gitlab-ci can only cache files in the project directory
 before_script:
    - mkdir -p .bower_cache
    - mkdir -p ~/.cache/bower
-   - ls .bower_cache
    - cp -a .bower_cache/. ~/.cache/bower
-   - ls ~/.cache/bower
 
 build:
    stage: build
    script:
       - bower install -q
+      - pulp build
+   artifacts:
+      paths:
+         - output
+         - bower_components
+
+test:
+   stage: test
+   script:
       - pulp test
 
 after_script:
    - cp -a ~/.cache/bower/. .bower_cache
-   - ls ~/.cache/bower
-   - ls .bower_cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,18 +6,20 @@ cache:
    paths:
       - .bower_cache
 
-# Moves the bower-cache files into .bower_cache, since
-# gitlab-ci can only cache files in the project directory
-before_script:
-   - mkdir -p .bower_cache
-   - mkdir -p ~/.cache/bower
-   - cp -a .bower_cache/. ~/.cache/bower
 
 build:
    stage: build
+   # Moves the bower-cache files into .bower_cache, since
+   # gitlab-ci can only cache files in the project directory
+   before_script:
+      - mkdir -p .bower_cache
+      - mkdir -p ~/.cache/bower
+      - cp -a .bower_cache/. ~/.cache/bower
    script:
       - bower install -q
       - pulp build
+   after_script:  
+      - cp -a ~/.cache/bower/. .bower_cache
    artifacts:
       paths:
          - output
@@ -27,6 +29,3 @@ test:
    stage: test
    script:
       - pulp test
-
-after_script:
-   - cp -a ~/.cache/bower/. .bower_cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,16 +6,20 @@ cache:
    paths:
       - .bower_cache
 
+before_script:
+   - mkdir -p .bower_cache
+   - mkdir -p ~/.cache/bower
+   - ls .bower_cache
+   - cp -a .bower_cache/. ~/.cache/bower
+   - ls ~/.cache/bower
+
 build:
    stage: build
    script:
-      - mkdir -p .bower_cache
-      - mkdir -p ~/.cache/bower
-      - ls .bower_cache
-      - cp -a .bower_cache/. ~/.cache/bower
-      - ls ~/.cache/bower
-      - bower install
-      - cp -a ~/.cache/bower/. .bower_cache
-      - ls ~/.cache/bower
-      - ls .bower_cache
+      - bower install -q
       - pulp test
+
+after_script:
+   - cp -a ~/.cache/bower/. .bower_cache
+   - ls ~/.cache/bower
+   - ls .bower_cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,11 @@ build:
    script:
       - mkdir -p .bower_cache
       - mkdir -p ~/.cache/bower
-      - cp -r .bower_cache ~/.cache/bower
+      - ls .bower_cache
+      - cp -a .bower_cache/. ~/.cache/bower
+      - ls ~/.cache/bower
       - bower install
-      - cp -r ~/.cache/bower .bower_cache
+      - cp -a ~/.cache/bower/. .bower_cache
+      - ls ~/.cache/bower
+      - ls .bower_cache
       - pulp test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ build:
       - mkdir -p ~/.cache/bower
       - cp -a .bower_cache/. ~/.cache/bower
    script:
-      - bower install -q
+      - bower install
       - pulp build
    after_script:  
       - cp -a ~/.cache/bower/. .bower_cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,12 +4,14 @@ image: registry.gitlab.com/csicar/purescript-sized-matrices
 cache:
    key: "$CI_COMMIT_REF_SLUG"
    paths:
-      - /home/pureuser/.cache/bower
+      - .bower_cache
 
 build:
    stage: build
    script:
+      - mkdir -p .bower_cache
+      - mkdir -p ~/.cache/bower
+      - cp -r .bower_cache ~/.cache/bower
       - bower install
-      - ls ~/.cache/bower
-      - ls /home/pureuser/.cache/bower
+      - cp -r ~/.cache/bower .bower_cache
       - pulp test


### PR DESCRIPTION
* Cache `.cache/bowere` by copying to `./.bower_cache`, because CI caching only works in the project directory
* Separate pipeline steps for build and test