### PR TITLE
Basic DSL for creating matrices

### DIFF
--- a/src/Data/Matrix.purs
+++ b/src/Data/Matrix.purs
@@ -23,6 +23,7 @@ module Data.Matrix
   , matrixOne
   , matrixZero
   , scalarMul
+  , (\\)
   ) where
 
 import Prelude
@@ -195,6 +196,8 @@ rowUnsafe (Matrix m) i = unsafePartial $ Array.unsafeIndex (Vec.toArray m) i
 -- |
 concatV :: ∀ h1 h2 h w a. Add h1 h2 h => Nat w => Matrix h1 w a -> Matrix h2 w a -> Matrix h w a
 concatV (Matrix a) (Matrix b) = Matrix $ Vec.concat a b
+
+infixr 3 concatV as \\
 
 -- |
 -- | ```purescript

--- a/src/Data/Matrix/Operations.purs
+++ b/src/Data/Matrix/Operations.purs
@@ -9,8 +9,7 @@ import Data.FunctorWithIndex (mapWithIndex)
 import Data.Vec (Vec)
 import Data.Maybe (Maybe, fromJust, fromMaybe)
 import Data.Vec as Vec
-import Data.Typelevel.Num (class Pos, class Nat, class Succ, class Pred, d0, toInt)
-import Data.Typelevel.Undefined (undefined)
+import Data.Typelevel.Num (class Pos, class Nat, class Succ, class Pred, d0, toInt, D1)
 import Partial.Unsafe (unsafePartial)
 
 consRowVec ::
@@ -41,6 +40,16 @@ consColVec vec (Matrix m) = Matrix $ Vec.zipWithE (Vec.cons) vec m
 -- | ```
 -- |
 infixr 5 consColVec as ⇥
+
+consSingle :: ∀ a s s'. Succ s s' => a -> Matrix D1 s a -> Matrix D1 s' a
+consSingle a = consColVec (Vec.singleton a)
+
+--| ```purescript
+--| > 1 & 2 & 3 & empty
+--|    [1, 2, 3]
+--| ```
+-- |
+infixr 4 consSingle as &
 
 -- |
 -- | ```purescript

--- a/src/Data/Matrix/Reps.purs
+++ b/src/Data/Matrix/Reps.purs
@@ -4,60 +4,70 @@ import Prelude
 import Data.Matrix
 import Data.Matrix.Operations
 import Data.Typelevel.Num.Reps (D0, D1, D2, D3)
+import Data.Typelevel.Num (class Nat)
 import Data.Vec as Vec
 
-empty :: ∀ a. Matrix D0 D0 a
-empty = Matrix Vec.empty
+emptyRow :: ∀ a w. Nat w => Matrix D0 w a
+emptyRow = Matrix Vec.empty
 
+empty :: ∀ a h. Nat h => Matrix h D0 a
+empty = Matrix $ Vec.replicate' Vec.empty
+
+matrix00 :: ∀ a. Matrix D0 D0 a
 matrix00 = empty
 
 singleton :: ∀ a. a -> Matrix D1 D1 a
 singleton x = Vec.singleton x ⤓ Vec.empty ⇥ empty
 
+row1 :: ∀ a. a -> Matrix D1 D1 a
+row1 = singleton
+
 matrix11 :: ∀ a. a -> Matrix D1 D1 a
 matrix11 = singleton
 
+row2 :: ∀ a. a -> a -> Matrix D1 D2 a
+row2 x11 x12 = x11 & x12 & empty
+
 matrix12 :: ∀ a. a -> a -> Matrix D1 D2 a
-matrix12 x11 x12 = Vec.singleton x11 ⇥ (singleton x12)
+matrix12 = row2
+
+row3 :: ∀ a. a -> a -> a -> Matrix D1 D3 a
+row3 x11 x12 x13 = x11 & x12 & x13 & empty
 
 matrix13 :: ∀ a. a -> a -> a -> Matrix D1 D3 a
-matrix13 x11 x12 x13 = Vec.singleton x11 ⇥ Vec.singleton x12 ⇥ (singleton x13)
+matrix13 = row3
 
 matrix21 :: ∀ a. a -> a -> Matrix D2 D1 a
 matrix21 x11 x21 =
-  Vec.singleton x11
-    ⤓ singleton x21
+  emptyRow
+    \\ row1 x11
+    \\ row1 x21
 
 matrix22 :: ∀ a. a -> a -> a -> a -> Matrix D2 D2 a
 matrix22 x11 x12 x21 x22 =
-  matrix12 x11 x12
-    `concatV`
-      matrix12 x21 x22
+  emptyRow
+    \\ row2 x11 x12
+    \\ row2 x21 x22
 
 matrix23 :: ∀ a. a -> a -> a -> a -> a -> a -> Matrix D2 D3 a
 matrix23 x11 x12 x13 x21 x22 x23 =
-  matrix13 x11 x12 x13
-    `concatV`
-      matrix13 x21 x22 x23
+  emptyRow
+    \\ row3 x11 x12 x13
+    \\ row3 x21 x22 x23
 
-matrix31 :: ∀ a. a -> a -> a -> Matrix D3 D1 a
-matrix31 x11 x21 x31 =
-  matrix21
-    x11
-    x21
-    `concatV`
-      singleton x31
+matrix31 ∷ ∀ a. a → a → a → Matrix D3 D1 a
+matrix31 x11 x21 x31 = singleton x11 \\ singleton x21 \\ singleton x31
 
 matrix32 :: ∀ a. a -> a -> a -> a -> a -> a -> Matrix D3 D2 a
-matrix32 x11 x12 x21 x22 x31 x32 = matrix31 x11 x21 x31 `concatH` matrix31 x12 x22 x32
+matrix32 x11 x12 x21 x22 x31 x32 =
+  emptyRow
+    \\ row2 x11 x12
+    \\ row2 x21 x22
+    \\ row2 x31 x32
 
 matrix33 :: ∀ a. a -> a -> a -> a -> a -> a -> a -> a -> a -> Matrix D3 D3 a
 matrix33 x11 x12 x13 x21 x22 x23 x31 x32 x33 =
-  Vec.vec3 x11 x12 x13
-    ⤓ matrix23
-        x21
-        x22
-        x23
-        x31
-        x32
-        x33
+  emptyRow
+    \\ row3 x11 x12 x13
+    \\ row3 x21 x22 x23
+    \\ row3 x31 x32 x33

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -6,10 +6,10 @@ import Data.Foldable (maximumBy, product)
 import Data.Function (on)
 import Data.FunctorWithIndex (mapWithIndex)
 import Data.Int (pow)
-import Data.Matrix (Matrix(..), column, fill, height, replicate', row, unsafeIndex, width, zipWithE)
+import Data.Matrix (Matrix(..), column, fill, height, replicate', row, unsafeIndex, width, zipWithE, (\\))
 import Data.Matrix.Algorithms (det, inverse)
-import Data.Matrix.Operations ((⇥), (⤓), findMaxIndex)
-import Data.Matrix.Reps (matrix11, matrix22, matrix33)
+import Data.Matrix.Operations ((⇥), (⤓), findMaxIndex, (&))
+import Data.Matrix.Reps (matrix11, matrix22, matrix33, empty, row3)
 import Data.Matrix.Transformations (resize, transpose, mkPermutation)
 import Data.Maybe (fromJust)
 import Data.Rational (Rational, fromInt, (%), toNumber)
@@ -28,22 +28,31 @@ import Test.Unit.Main (runTest)
 import Test.Unit.QuickCheck (quickCheck)
 import Data.VectorField ((.*), (*.))
 import Effect.Class.Console (logShow)
-import Type.Proxy (Proxy(..), Proxy2(..))
 
 a1 :: Matrix D3 D3 Number
-a1 = matrix33 1.0 4.0 (-1.0) 3.0 0.0 5.0 2.0 2.0 1.0
+a1 =
+  row3 1.0 4.0 (-1.0)
+    \\ row3 3.0 0.0 5.0
+    \\ row3 2.0 2.0 1.0
 
 a2 :: Matrix D3 D3 Rational
-a2 = map fromInt $ matrix33 1 4 (-1) 3 (-12) 8 2 (-6) 3
+a2 =
+  map fromInt
+    $ row3 1 4 (-1)
+    \\ row3 3 (-12) 8
+    \\ row3 2 (-6) 3
 
 a3 :: Matrix D3 D3 Number
-a3 = matrix33 0.0 4.0 (-1.0) 1.0 2.0 1.0 2.0 1.0 5.0
+a3 =
+  row3 0.0 4.0 (-1.0)
+    \\ row3 1.0 2.0 1.0
+    \\ row3 2.0 1.0 5.0
 
 a4 :: Matrix D3 D3 Rational
-a4 = map fromInt $ matrix33 1 4 5 1 6 11 2 6 7
+a4 = map fromInt $ row3 1 4 5 \\ row3 1 6 11 \\ row3 2 6 7
 
 a5 ∷ Matrix D3 D3 Number
-a5 = matrix33 2.0 0.0 0.0 0.0 3.0 0.0 0.0 0.0 4.0
+a5 = row3 2.0 0.0 0.0 \\ row3 0.0 3.0 0.0 \\ row3 0.0 0.0 4.0
 
 main ::
   Effect


### PR DESCRIPTION
This adds `\\` and `&` operators to create matrices:

```purescript
m = 1 & 2 & 3 & empty
  \\  4 & 5 & 6 & empty
```

also added `row[N]` functions which come in handy with `\\`

```purescript
m = row3 1 2 3
  \\ row3 4 5 6
```